### PR TITLE
Do not check for test dependencies for every test run

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,7 @@ install-requires:
 	@echo "*** Installing the dependencies required for testing and analysis ***"
 	dnf install -y $(TEST_DEPENDENCIES)
 
-test: check-requires
+test:
 	$(MAKE) check
 
 ci:


### PR DESCRIPTION
The "check-requires" target uses rpm to check for test dependencies
and this obviously doesn't work on non-RPM distribution.
We should come up with some better solution for this (or delete
it all) but for now just skip the check when running "make test".