### PR TITLE
Actually translate the units when expected

### DIFF
--- a/src/bs_size.c
+++ b/src/bs_size.c
@@ -243,7 +243,7 @@ static bool multiply_size_by_unit (mpfr_t size, char *unit_str) {
     /* not found among the binary and decimal units, let's try their translated
        verions */
     for (bunit=BS_BUNIT_B; bunit < BS_BUNIT_UNDEF; bunit++)
-        if (strncasecmp (unit_str, b_units[bunit-BS_BUNIT_B], unit_str_len) == 0) {
+        if (strncasecmp (unit_str, _(b_units[bunit-BS_BUNIT_B]), unit_str_len) == 0) {
             pwr = (uint64_t) bunit - BS_BUNIT_B;
             mpfr_mul_2exp (size, size, 10 * pwr, MPFR_RNDN);
             return true;
@@ -252,7 +252,7 @@ static bool multiply_size_by_unit (mpfr_t size, char *unit_str) {
     mpfr_init2 (dec_mul, BS_FLOAT_PREC_BITS);
     mpfr_set_ui (dec_mul, 1000, MPFR_RNDN);
     for (dunit=BS_DUNIT_B; dunit < BS_DUNIT_UNDEF; dunit++)
-        if (strncasecmp (unit_str, d_units[dunit-BS_DUNIT_B], unit_str_len) == 0) {
+        if (strncasecmp (unit_str, _(d_units[dunit-BS_DUNIT_B]), unit_str_len) == 0) {
             pwr = (uint64_t) (dunit - BS_DUNIT_B);
             mpfr_pow_ui (dec_mul, dec_mul, pwr, MPFR_RNDN);
             mpfr_mul (size, size, dec_mul, MPFR_RNDN);

--- a/tests/libbytesize_unittest.py
+++ b/tests/libbytesize_unittest.py
@@ -8,7 +8,7 @@ import ctypes
 
 from locale_utils import get_avail_locales, requires_locales
 
-from bytesize import SizeStruct, KiB, ROUND_UP, ROUND_DOWN, ROUND_HALF_UP, OverflowError
+from bytesize import SizeStruct, KiB, GiB, ROUND_UP, ROUND_DOWN, ROUND_HALF_UP, OverflowError
 
 DEFAULT_LOCALE = "en_US.utf8"
 
@@ -388,6 +388,14 @@ class SizeTestCase(unittest.TestCase):
 
         strSizeStruct = SizeStruct.new_from_str("100 GiB").human_readable(KiB, 0, False)
         self.assertEqual(strSizeStruct, "100 GiB")
+
+        # test that the result of human_readable() can be parsed back
+        strSizeStruct = SizeStruct.new_from_str("100 GiB").human_readable(GiB, 0, False)
+        self.assertEqual(SizeStruct.new_from_str(strSizeStruct).get_bytes(), (100 * 1024**3, 1))
+
+        # even if translated
+        strSizeStruct = SizeStruct.new_from_str("100 GiB").human_readable(GiB, 0, True)
+        self.assertEqual(SizeStruct.new_from_str(strSizeStruct).get_bytes(), (100 * 1024**3, 1))
     #enddef
 
     def testSgn(self):


### PR DESCRIPTION
There's a second run through all the supported size units which
is supposed to match in case the input size unit was
translated. However, it needs to compare the input to actually
translated size units not the original strings.

Resolves: rhbz#1484676