### PR TITLE
Add gcc to BuildRequires

### DIFF
--- a/dist/libbytesize.spec.in
+++ b/dist/libbytesize.spec.in
@@ -18,6 +18,7 @@ License:     LGPLv2+
 URL:         https://github.com/storaged-project/libbytesize
 Source0:     https://github.com/storaged-project/libbytesize/releases/download/%{version}-%{release}/%{name}-%{version}.tar.gz
 
+BuildRequires: gcc
 BuildRequires: gmp-devel
 BuildRequires: mpfr-devel
 BuildRequires: pcre-devel


### PR DESCRIPTION
It won't be in build root automatically starting from Fedora 29.