### PR TITLE
Fix licence header for "gettext.h"

### DIFF
--- a/src/gettext.h
+++ b/src/gettext.h
@@ -3,16 +3,16 @@
    Foundation, Inc.
 
    This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
+   it under the terms of the GNU Lesser General Public License as published by
    the Free Software Foundation; either version 2, or (at your option)
    any later version.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
+   GNU Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License along
+   You should have received a copy of the GNU Lesser General Public License along
    with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
 #ifndef _LIBGETTEXT_H


### PR DESCRIPTION
This file is imported from gnulib and it is available under both
GNU GPLv2 and GNU LGPLv2 and we obviously want the LGPL version.
File was generated/imported using "gnulib-tool --lgpl --import gettext"