### PR TITLE
Run all libbytesize tests from one scripts

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,7 +2,7 @@ AM_TESTS_ENVIRONMENT = top_srcdir="$(top_srcdir)" top_builddir="$(top_builddir)"
 
 dist_noinst_SCRIPTS = libbytesize_unittest.sh libbytesize_unittest.py lbs_py_override_unittest.py locale_utils.py testenv.sh canary_tests.sh
 
-TESTS = libbytesize_unittest.sh lbs_py_override_unittest.py canary_tests.sh
+TESTS = libbytesize_unittest.sh canary_tests.sh
 
 # Add the translation-canary source files to the tarball
 EXTRA_DIST = $(top_srcdir)/translation-canary/translation_canary/*.py \

--- a/tests/libbytesize_unittest.sh.in
+++ b/tests/libbytesize_unittest.sh.in
@@ -9,10 +9,12 @@ fi
 
 if [ @WITH_PYTHON2@ = 1 ]; then
     python2 ${srcdir}/libbytesize_unittest.py || status=1
+    python2 ${srcdir}/lbs_py_override_unittest.py || status=1
 fi
 
 if [ @WITH_PYTHON3@ = 1 ]; then
     python3 ${srcdir}/libbytesize_unittest.py || status=1
+    python3 ${srcdir}/lbs_py_override_unittest.py || status=1
 fi
 
 if [ @WITH_PYTHON2@ = 1 ]; then


### PR DESCRIPTION
This also make sure we run tests with all supported python versions.