### PR TITLE
Remove Python 2 support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,7 @@ dist-hook:
 	done
 
 run-ipython: all
-	LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=$(PYTHONDIR) ipython
+	LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=$(PYTHONDIR) ipython3
 
 check-requires:
 	@echo "*** Checking if the dependencies required for testing and analysis are available ***"

--- a/configure.ac
+++ b/configure.ac
@@ -50,22 +50,6 @@ AC_CHECK_HEADERS([langinfo.h gmp.h mpfr.h stdint.h stdbool.h stdarg.h string.h s
                  [LIBBYTESIZE_SOFT_FAILURE([Header file $ac_header not found.])],
                  [])
 
-AC_ARG_WITH([python2],
-    AS_HELP_STRING([--with-python2], [support python2 @<:@default=check@:>@]),
-    [],
-    [with_python2=check])
-
-AC_SUBST(WITH_PYTHON2, 0)
-if test "x$with_python2" != "xno"; then
-    AC_PATH_PROG([python2], [python2], [no])
-    AS_IF([test "x$python2" == "xno"],
-    [if test "x$with_python2" = "xyes"; then
-      LIBBYTESIZE_SOFT_FAILURE([Python2 support requested, but python2 is not available])
-      fi],
-    [AC_SUBST(WITH_PYTHON2, 1)])
-fi
-AM_CONDITIONAL(WITH_PYTHON2, test "x$with_python2" != "xno" -a "x$python2" != "xno")
-
 AC_ARG_WITH([python3],
     AS_HELP_STRING([--with-python3], [support python3 @<:@default=check@:>@]),
     [],

--- a/dist/libbytesize.spec.in
+++ b/dist/libbytesize.spec.in
@@ -1,5 +1,4 @@
 %define realname bytesize
-%define with_python2 @WITH_PYTHON2@
 %define with_python3 @WITH_PYTHON3@
 %define with_gtk_doc @WITH_GTK_DOC@
 
@@ -8,13 +7,7 @@
 %define python3_opts --without-python3
 %endif
 
-# python2 is not available on RHEL > 7 and not needed on Fedora > 28
-%if 0%{?rhel} > 7 || 0%{?fedora} > 28 || %{with_python2} == 0
-%define with_python2 0
-%define python2_opts --without-python2
-%endif
-
-%define configure_opts %{?python3_opts} %{?python2_opts}
+%define configure_opts %{?python3_opts}
 
 Name:        libbytesize
 Version:     1.4
@@ -29,9 +22,6 @@ BuildRequires: gmp-devel
 BuildRequires: mpfr-devel
 BuildRequires: pcre-devel
 BuildRequires: gettext-devel
-%if %{with_python2}
-BuildRequires: python2-devel
-%endif
 %if %{with_python3}
 BuildRequires: python3-devel
 %endif
@@ -52,19 +42,6 @@ Requires: %{name}%{?_isa} = %{version}-%{release}
 %description devel
 This package contains header files and pkg-config files needed for development
 with the libbytesize library.
-
-%if %{with_python2}
-%package -n python2-%{realname}
-Summary: Python 2 bindings for libbytesize
-%{?python_provide:%python_provide python2-%{realname}}
-%{?python_provide:%python_provide python2-libbytesize}
-Requires: %{name}%{?_isa} = %{version}-%{release}
-Requires: python2-six
-
-%description -n python2-%{realname}
-This package contains Python 2 bindings for libbytesize making the use of
-the library from Python 2 easier and more convenient.
-%endif
 
 %if %{with_python3}
 %package -n python3-%{realname}
@@ -106,12 +83,6 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 %{_libdir}/pkgconfig/bytesize.pc
 %if %{with_gtk_doc}
 %{_datadir}/gtk-doc/html/libbytesize
-%endif
-
-%if %{with_python2}
-%files -n python2-%{realname}
-%dir %{python2_sitearch}/bytesize
-%{python2_sitearch}/bytesize/*
 %endif
 
 %if %{with_python3}

--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -1,14 +1,7 @@
-if WITH_PYTHON2
-pylibdir = $(shell python -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib(1,0,prefix='${exec_prefix}'))")
-
-pybytesizedir     = $(pylibdir)/bytesize
-dist_pybytesize_DATA = bytesize.py __init__.py
-endif
-
 if WITH_PYTHON3
 py3libdir = $(shell python3 -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib(1,0,prefix='${exec_prefix}'))")
 py3bytesizedir    = $(py3libdir)/bytesize
-nodist_py3bytesize_DATA = bytesize.py __init__.py
+dist_py3bytesize_DATA = bytesize.py __init__.py
 endif
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/tests/lbs_py_override_unittest.py
+++ b/tests/lbs_py_override_unittest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 import unittest
@@ -306,5 +306,3 @@ class SizeTestCase(unittest.TestCase):
 if __name__=='__main__':
     unittest.main()
 #endif
-
-

--- a/tests/libbytesize_unittest.py
+++ b/tests/libbytesize_unittest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 import locale
@@ -759,4 +759,3 @@ if __name__=='__main__':
         sys.argv = [sys.argv[0]]
     unittest.main()
 #endif
-

--- a/tests/libbytesize_unittest.sh.in
+++ b/tests/libbytesize_unittest.sh.in
@@ -7,18 +7,9 @@ if [ -z "$srcdir" ]; then
     srcdir="$(dirname "$0")"
 fi
 
-if [ @WITH_PYTHON2@ = 1 ]; then
-    python2 ${srcdir}/libbytesize_unittest.py || status=1
-    python2 ${srcdir}/lbs_py_override_unittest.py || status=1
-fi
-
 if [ @WITH_PYTHON3@ = 1 ]; then
     python3 ${srcdir}/libbytesize_unittest.py || status=1
     python3 ${srcdir}/lbs_py_override_unittest.py || status=1
-fi
-
-if [ @WITH_PYTHON2@ = 1 ]; then
-    python2 ${srcdir}/libbytesize_unittest.py fr_FR.UTF8 || status=1
 fi
 
 if [ @WITH_PYTHON3@ = 1 ]; then


### PR DESCRIPTION
Python 2 EOL is close and we are no longer shipping python2
package in newest distributions, so it makes sense to remove
Python 2 support entirely.