### PR TITLE
fix out of tree build failure

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -5,7 +5,7 @@ dist_man1_MANS = bscalc.man
 
 install-exec-local:
 	install -d ${DESTDIR}${bindir}
-	install -m0755 ${srcdir}/bs_calc.py ${DESTDIR}${bindir}/bscalc
+	install -m0755 ${builddir}/bs_calc.py ${DESTDIR}${bindir}/bscalc
 
 uninstall-local:
 	rm ${DESTDIR}${bindir}/bscalc


### PR DESCRIPTION
Since commit [116da95 Add the '--version' option to bs_calc.py] applied,
while build out of tree, there is a install failure
...
|install -m0755 ../../git/tools/bs_calc.py /usr/bin/bscalc
|install: cannot stat '../../git/tools/bs_calc.py': No such file or directory
...

The generated bs_calc.py locates in builddir rather than srcdir

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>