### PR TITLE
src/gettext: fix warning if gettext is already present

### DIFF
--- a/src/gettext.h
+++ b/src/gettext.h
@@ -105,6 +105,7 @@
    and other string expressions won't work.
    The macro's expansion is not parenthesized, so that it is suitable as
    initializer for static 'char[]' or 'const char[]' variables.  */
+#undef gettext_noop
 #define gettext_noop(String) String
 
 /* The separator between msgctxt and msgid in a .mo file.  */


### PR DESCRIPTION
Building on an environment where gettext is already present leads to
emitting a warning about gettext_noop() alread defined. And if -Werror
is passed this warning will be treated like an error, so let's #undef
gettext_noop() before #define it.

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>