### PR TITLE
Require the same version of python3-bytesize in libbytesize-tools

### DIFF
--- a/dist/libbytesize.spec.in
+++ b/dist/libbytesize.spec.in
@@ -63,7 +63,7 @@ the library from Python 3 easier and more convenient.
 %if %{with_tools}
 %package tools
 Summary: Various nice tools based on libbytesize
-Requires: python3-%{realname}
+Requires: python3-%{realname} = %{version}-%{release}
 
 %description tools
 Various nice tools based on libbytesize, in particular the calculator


### PR DESCRIPTION
Otherwise the bindings may be missing something the tools need.