### PR TITLE
travis: Add --nogpgcheck when using dnf on rawhide

### DIFF
--- a/.travis/Dockerfile.fedora-rawhide
+++ b/.travis/Dockerfile.fedora-rawhide
@@ -1,3 +1,3 @@
 FROM fedora:rawhide
 
-RUN dnf -y install ansible
+RUN dnf -y install ansible --nogpgcheck

--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -24,7 +24,7 @@
     when: ansible_distribution == 'Fedora'
 
   - name: Install build dependencies (Fedora)
-    command: "dnf -y builddep libbytesize"
+    command: "dnf -y builddep libbytesize --nogpgcheck"
     args:
       warn: false
     when: ansible_distribution == 'Fedora'


### PR DESCRIPTION
GPG keys/signatures are regularly broken in rawhide composes and
repos.