### PR TITLE
tools: Read input from stdin when not running in a tty

### DIFF
--- a/tools/bs_calc.py.in
+++ b/tools/bs_calc.py.in
@@ -110,7 +110,11 @@ def _main():
                     help="Show only single 'best' result", action="store_true")
     ap.add_argument(metavar="EXPRESSION_PART", dest="expressions", nargs="+")
 
-    args = ap.parse_args()
+    if not sys.stdin.isatty():
+        stdin = sys.stdin.read().splitlines()
+        args = ap.parse_args(sys.argv[1:] + stdin)
+    else:
+        args = ap.parse_args()
 
     try:
         tokens = _tokenize(" ".join(args.expressions))


### PR DESCRIPTION
This allows piping input into bscalc, e.g. running

$ echo "10g + 100m" | bscalc -H
10.1 GiB