### PR TITLE
travis: Do not run tests in privileged container in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   # directory to /app inside the container and let the container running
   # in the background. The resulting container ID will be saved to
   # container_id so we can reference it later on.
-  - docker run --privileged --volume "$(pwd):/app" --workdir "/app" --tty --detach myimage bash > container_id
+  - docker run --volume "$(pwd):/app" --workdir "/app" --tty --detach myimage bash > container_id
   - docker exec "$(cat container_id)" ansible-playbook -i "localhost," -c local misc/install-test-dependencies.yml
 
 script:


### PR DESCRIPTION
We don't need privileged container for libbytesize tests.

Fixes: #84