### PR TITLE
Add support to ppc64le for debian build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: minimal
+arch: 
+  - amd64
+  - ppc64le
 services: docker
 sudo: required
 
 env:
   - DOCKER_FILE=".travis/Dockerfile.fedora-rawhide"
   - DOCKER_FILE=".travis/Dockerfile.debian-testing"
-
+  
+jobs:
+  exclude:
+   - arch: ppc64le
+     env: DOCKER_FILE=".travis/Dockerfile.fedora-rawhide"
+  
 before_install:
   # Create a docker image called "myimage".
   - docker build -t myimage -f "$DOCKER_FILE" .
@@ -15,7 +23,12 @@ before_script:
   # directory to /app inside the container and let the container running
   # in the background. The resulting container ID will be saved to
   # container_id so we can reference it later on.
-  - docker run --privileged --volume "$(pwd):/app" --workdir "/app" --tty --detach myimage bash > container_id
+  - >
+   if [ "$TRAVIS_CPU_ARCH" = "ppc64le" ]; then
+     docker run --volume "$(pwd):/app" --workdir "/app" --tty --detach myimage bash > container_id;
+   else
+     docker run --privileged --volume "$(pwd):/app" --workdir "/app" --tty --detach myimage bash > container_id;
+   fi  
   - docker exec "$(cat container_id)" ansible-playbook -i "localhost," -c local misc/install-test-dependencies.yml
 
 script:


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date. 