### PR TITLE
Make sure Size can be interpreted as integer in Python 3.10

### DIFF
--- a/src/python/bytesize.py
+++ b/src/python/bytesize.py
@@ -591,6 +591,9 @@ class Size(object):
     def __int__(self):
         return self.get_bytes()
 
+    def __index__(self):
+        return self.get_bytes()
+
     def __float__(self):
         return float(self.get_bytes())
 

--- a/tests/lbs_py_override_unittest.py
+++ b/tests/lbs_py_override_unittest.py
@@ -4,6 +4,7 @@
 import unittest
 import copy
 import locale
+import ctypes
 
 from decimal import Decimal
 from locale_utils import get_avail_locales, requires_locales
@@ -251,6 +252,10 @@ class SizeTestCase(unittest.TestCase):
         self.assertTrue(size1)
         self.assertFalse(size2)
     #enddef
+
+    def testInt(self):
+        # just to make sure Size can be correctly interpreted as int in python 3.10
+        ctypes.c_int(Size("1 GiB"))
 
     def testAbs(self):
         size1 = Size("1 GiB")


### PR DESCRIPTION
Having __int__ is no longer enough to have Size interpreted as
integer. Starting with 3.10 we need to implement __index__ for
that because __int__ is not considered lossless and is also
available for floats and similar "non-integer" numbers where it is
used for lossy conversions (rounding).
See https://bugs.python.org/issue37999 for more information.