### PR TITLE
Do not use distutils to get Python library path

### DIFF
--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -1,5 +1,5 @@
 if WITH_PYTHON3
-py3libdir = $(shell python3 -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib(1,0,prefix='${exec_prefix}'))")
+py3libdir = $(shell python3 -c "import sysconfig; print(sysconfig.get_path('platlib', vars={'platbase': '${exec_prefix}'}))")
 py3bytesizedir    = $(py3libdir)/bytesize
 dist_py3bytesize_DATA = bytesize.py __init__.py
 endif


### PR DESCRIPTION
distutils is deprecated and will be removed in Python 3.12.
sysconfig module provides replacement for distutils.sysconfig.