### PR TITLE
build: avoid bashisms in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ AC_ARG_WITH([python3],
 AC_SUBST(WITH_PYTHON3, 0)
 if test "x$with_python3" != "xno"; then
     AC_PATH_PROG([python3], [python3], [no])
-    AS_IF([test "x$python3" == "xno"],
+    AS_IF([test "x$python3" = "xno"],
     [if test "x$with_python3" = "xyes"; then
       LIBBYTESIZE_SOFT_FAILURE([Python3 support requested, but python3 is not available])
       fi],
@@ -77,7 +77,7 @@ AC_ARG_WITH([gtk-doc],
 AC_SUBST(WITH_GTK_DOC, 0)
 if test "x$with_gtk_doc" != "xno"; then
     AC_PATH_PROG([gtkdoc_scan], [gtkdoc-scan], [no])
-    AS_IF([test "x$gtkdoc_scan" == "xno"],
+    AS_IF([test "x$gtkdoc_scan" = "xno"],
     [if test "x$with_gtk_doc" = "xyes"; then
       LIBBYTESIZE_SOFT_FAILURE([Building documentation with gtk-doc requested, but not available])
       fi],


### PR DESCRIPTION
configure needs to be executable by a POSIX-compliant shell (/bin/sh)
and while this is often Bash, which tolerates non-POSIX statements, it
might sometimes be e.g. dash which doesn't.

Signed-off-by: Sam James <sam@gentoo.org>