### PR TITLE
tests: Use UTF-8 locale instead of utf8

### DIFF
--- a/tests/lbs_py_override_unittest.py
+++ b/tests/lbs_py_override_unittest.py
@@ -18,13 +18,13 @@ class SizeTestCase(unittest.TestCase):
         unittest.TestCase.setUpClass()
         cls.avail_locales = get_avail_locales()
 
-    @requires_locales({'en_US.utf8'})
+    @requires_locales({'en_US.UTF-8'})
     def setUp(self):
-        locale.setlocale(locale.LC_ALL,'en_US.utf8')
+        locale.setlocale(locale.LC_ALL,'en_US.UTF-8')
         self.addCleanup(self._clean_up)
 
     def _clean_up(self):
-        locale.setlocale(locale.LC_ALL,'en_US.utf8')
+        locale.setlocale(locale.LC_ALL,'en_US.UTF-8')
 
     # test operator functions
     def testOperatorPlus(self):

--- a/tests/libbytesize_unittest.py
+++ b/tests/libbytesize_unittest.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     from bytesize.bytesize import SizeStruct
 
-DEFAULT_LOCALE = "en_US.utf8"
+DEFAULT_LOCALE = "en_US.UTF-8"
 
 class SizeTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Apparently en_US.utf8 doesn't work on all systems with setlocale.

Fixes: #105