### PR TITLE
Fix skipping tests when required locale is missing

### DIFF
--- a/tests/libbytesize_unittest.py
+++ b/tests/libbytesize_unittest.py
@@ -6,7 +6,7 @@ import unittest
 import sys
 import ctypes
 
-from locale_utils import get_avail_locales, requires_locales
+from locale_utils import get_avail_locales, missing_locales, requires_locales
 
 from bytesize import KiB, GiB, ROUND_UP, ROUND_DOWN, ROUND_HALF_UP, OverflowError
 
@@ -26,8 +26,10 @@ class SizeTestCase(unittest.TestCase):
         unittest.TestCase.setUpClass()
         cls.avail_locales = get_avail_locales()
 
-    @requires_locales({DEFAULT_LOCALE})
     def setUp(self):
+        missing = missing_locales({DEFAULT_LOCALE}, self.avail_locales)
+        if missing:
+            self.skipTest("requires missing locales: %s" % missing)
         locale.setlocale(locale.LC_ALL, DEFAULT_LOCALE)
         self.addCleanup(self._clean_up)
 

--- a/tests/libbytesize_unittest.sh.in
+++ b/tests/libbytesize_unittest.sh.in
@@ -13,7 +13,7 @@ if [ @WITH_PYTHON3@ = 1 ]; then
 fi
 
 if [ @WITH_PYTHON3@ = 1 ]; then
-    python3 ${srcdir}/libbytesize_unittest.py fr_FR.UTF8 || status=1
+    python3 ${srcdir}/libbytesize_unittest.py fr_FR.UTF-8 || status=1
 fi
 
 exit $status

--- a/tests/locale_utils.py
+++ b/tests/locale_utils.py
@@ -6,6 +6,12 @@ import subprocess
 def get_avail_locales():
     return {loc.decode(errors="replace").strip() for loc in subprocess.check_output(["locale", "-a"]).split()}
 
+
+def missing_locales(required, available):
+    canon_locales = {loc.replace("UTF-8", "utf8") for loc in required}
+    return canon_locales - set(available)
+
+
 def requires_locales(locales):
     """A decorator factory to skip tests that require unavailable locales
 
@@ -16,10 +22,9 @@ def requires_locales(locales):
 
     """
 
-    canon_locales = {loc.replace("UTF-8", "utf8") for loc in locales}
     def decorator(test_method):
         def decorated(test, *args):
-            missing = canon_locales - set(test.avail_locales)
+            missing = missing_locales(locales, test.avail_locales)
             if missing:
                 test.skipTest("requires missing locales: %s" % missing)
             else:


### PR DESCRIPTION
We cannot use the decorator to skip the tests if the "default"
locale is missing because the decorator evaluates before we set
the locale from the cmdline argument.

Fixes: #105