### PR TITLE
Add a GitHub action for running csmock static analysis

### DIFF
--- a/.github/workflows/csmock.yml
+++ b/.github/workflows/csmock.yml
@@ -1,0 +1,44 @@
+name: Run static analysis using csmock
+
+env:
+  CSMOCK_CHROOTS: "default"
+  CSMOCK_TOOLS: "clang cppcheck gcc"
+
+on:
+  pull_request:
+    branches:
+     - master
+
+jobs:
+  build:
+    name: csmock
+    runs-on: ubuntu-22.04
+    env:
+      CI_CONTAINER: libbytesize-ci-csmock
+    steps:
+      - name: Checkout libbytesize repository
+        uses: actions/checkout@v3
+
+      - name: Install podman
+        run: |
+          sudo apt -qq update
+          sudo apt -y -qq install podman
+
+      - name: Build the container
+        run: |
+          sudo podman build --no-cache -t ${{ env.CI_CONTAINER }} -f misc/csmock.Dockerfile .
+
+      - name: Run csmock build in the container
+        run: |
+          sudo podman run -i --rm --privileged --volume "$(pwd):/app" --workdir "/app" ${{ env.CI_CONTAINER }} <<EOF
+          set -eux
+          ansible-playbook -i "localhost," -c local misc/install-test-dependencies.yml
+          /ci/run_csmock_tests -c /ci/copr-builder.conf -p libbytesize-udisks -t ${{ env.CSMOCK_TOOLS }} -r ${{ env.CSMOCK_CHROOTS }}
+          EOF
+
+      - name: Upload the csmock logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: csmock_logs
+          path: csmock_*/*

--- a/misc/csmock.Dockerfile
+++ b/misc/csmock.Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.fedoraproject.org/fedora:latest
+
+RUN set -e; \
+  dnf install -y ansible python3-pip rpm-build mock csmock git; \
+  pip3 install copr-builder; \
+  git clone --depth 1 https://github.com/storaged-project/ci.git;
+
+WORKDIR /


### PR DESCRIPTION
This was surprisingly easy to implement. The idea is to replace the csmock test we currently run in our Jenkins. Installing mock and csmock on Ubuntu would be very complicated so this runs in a Fedora container. The idea is to add the action to all our projects so I've created a [new repository](https://github.com/storaged-project/ci) for shared scripts and config files. I plan to experiment with this a little bit more and also move the RPM builds to GH actions (it will be very similar, but will require few changes) so I mostly posting this PR to get some feedback (libbytesize is my favourite CI playground).