### PR TITLE
spec: Change license string to the SPDX format required by Fedora

### DIFF
--- a/dist/libbytesize.spec.in
+++ b/dist/libbytesize.spec.in
@@ -19,7 +19,7 @@ Name:        libbytesize
 Version:     2.7
 Release:     1%{?dist}
 Summary:     A library for working with sizes in bytes
-License:     LGPLv2+
+License:     LGPL-2.1-or-later
 URL:         https://github.com/storaged-project/libbytesize
 Source0:     https://github.com/storaged-project/libbytesize/releases/download/%{version}-%{release}/%{name}-%{version}.tar.gz
 


### PR DESCRIPTION
https://fedoraproject.org/wiki/Changes/SPDX_Licenses_Phase_1