### PR TITLE
misc: Remove "warn: false" from Ansible "command"

### DIFF
--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -25,8 +25,6 @@
 
   - name: Install build dependencies (Fedora)
     command: "dnf -y builddep libbytesize --nogpgcheck"
-    args:
-      warn: false
     when: ansible_distribution == 'Fedora'
 
   - name: Install test dependencies (Fedora)


### PR DESCRIPTION
The "warn" parameter has been removed in the latest Ansible release.