### PR TITLE
ci: Define per-job actions for Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,12 +1,3 @@
-actions:
-  post-upstream-clone:
-    - './autogen.sh'
-    - './configure'
-  create-archive:
-    - 'make'
-    - 'make local'
-    - 'bash -c "ls *.tar*"'
-
 jobs:
 - job: copr_build
   metadata:
@@ -21,6 +12,14 @@ jobs:
     - epel-9-ppc64le
     - epel-9-x86_64
   trigger: pull_request
+  actions:
+    post-upstream-clone:
+      - './autogen.sh'
+      - './configure'
+    create-archive:
+      - 'make'
+      - 'make local'
+      - 'bash -c "ls *.tar*"'
 
 - job: copr_build
   trigger: commit
@@ -28,6 +27,14 @@ jobs:
   project: blivet-daily
   branch: master
   preserve_project: true
+  actions:
+    post-upstream-clone:
+      - './autogen.sh'
+      - './configure'
+    create-archive:
+      - 'make'
+      - 'make local'
+      - 'bash -c "ls *.tar*"'
 
 - job: copr_build
   trigger: commit
@@ -35,11 +42,22 @@ jobs:
   project: udisks-daily
   branch: master
   preserve_project: true
+  actions:
+    post-upstream-clone:
+      - './autogen.sh'
+      - './configure'
+    create-archive:
+      - 'make'
+      - 'make local'
+      - 'bash -c "ls *.tar*"'
 
 - job: propose_downstream
   trigger: release
   dist_git_branches:
     - fedora-all
+  actions:
+    post-upstream-clone:
+      - 'bash -c "bash -c "curl -sL https://github.com/storaged-project/libbytesize/releases/download/`git describe`/libbytesize-`git describe`.tar.gz | tar -zxvf - libbytesize-`git describe`/dist/libbytesize.spec --strip-components 1"'
 
 - job: koji_build
   trigger: commit


### PR DESCRIPTION
We need different actions for the Copr builds and for the propose downstream job which runs in a different environment.