### PR TITLE
ci: Manually prepare spec file for Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,8 +1,10 @@
 actions:
   post-upstream-clone:
+    - 'cp dist/libbytesize.spec.in dist/libbytesize.spec'
+    - 'sed -i -e "s/@WITH_PYTHON3@/1/g" -e "s/@WITH_GTK_DOC@/1/g" -e "s/@WITH_TOOLS@/1/g" dist/libbytesize.spec'
+  create-archive:
     - './autogen.sh'
     - './configure'
-  create-archive:
     - 'make'
     - 'make local'
     - 'bash -c "ls *.tar*"'


### PR DESCRIPTION
We can't run ./configure for some jobs in Packit, but we don't really need to -- we can replace the constants manually with sed, because for the Packit builds, we always want to build the entire project.