### PR TITLE
build: Exit before AC_OUTPUT on error

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -69,5 +69,5 @@ echo "*** Libbytesize encountered the following issues during configuration:"
 echo "$libbytesize_failure_messages"
 echo ""
 echo "*** Libbytesize will not successfully build without these missing dependencies"
-exit 1
+AS_EXIT(1)
 ])])dnl

--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,8 @@ AS_IF([test "x$with_tools" != "xno" && test "x$with_python3" != "xyes"],
       [LIBBYTESIZE_SOFT_FAILURE([Tools require Python3 bindings])],
       [])
 
+LIBBYTESIZE_FAILURES
+
 AC_OUTPUT
 
 dnl ==========================================================================
@@ -124,4 +126,3 @@ echo "
         tools:                      ${with_tools}
 "
 
-LIBBYTESIZE_FAILURES


### PR DESCRIPTION
In case of configure failures an exit code 1 will be returned, yet it's apparently not always checked by distributors. And since AC_OUTPUT has already generated target Makefiles, some issues like a missing pcre library (that expands to an empty string) may not cause immediate build failure yet the generated object files may not be entirely valid.

Fixes #129