### PR TITLE
packit: Bump release only for daily Copr builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,6 +1,5 @@
 actions:
   post-upstream-clone:
-    - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:     99%{?dist}/\" dist/libbytesize.spec.in"'
     - 'cp dist/libbytesize.spec.in dist/libbytesize.spec'
     - 'sed -i -e "s/@WITH_PYTHON3@/1/g" -e "s/@WITH_GTK_DOC@/1/g" -e "s/@WITH_TOOLS@/1/g" dist/libbytesize.spec'
   create-archive:
@@ -31,6 +30,18 @@ jobs:
   project: blivet-daily
   branch: main
   preserve_project: true
+  actions:
+    post-upstream-clone:
+      # bump release to 99 to always be ahead of Fedora builds
+      - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:     99%{?dist}/\" dist/libbytesize.spec.in"'
+      - 'cp dist/libbytesize.spec.in dist/libbytesize.spec'
+      - 'sed -i -e "s/@WITH_PYTHON3@/1/g" -e "s/@WITH_GTK_DOC@/1/g" -e "s/@WITH_TOOLS@/1/g" dist/libbytesize.spec'
+    create-archive:
+      - './autogen.sh'
+      - './configure'
+      - 'make'
+      - 'make local'
+      - 'bash -c "ls *.tar*"'
 
 - job: copr_build
   trigger: commit
@@ -38,6 +49,18 @@ jobs:
   project: udisks-daily
   branch: main
   preserve_project: true
+  actions:
+    post-upstream-clone:
+      # bump release to 99 to always be ahead of Fedora builds
+      - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:     99%{?dist}/\" dist/libbytesize.spec.in"'
+      - 'cp dist/libbytesize.spec.in dist/libbytesize.spec'
+      - 'sed -i -e "s/@WITH_PYTHON3@/1/g" -e "s/@WITH_GTK_DOC@/1/g" -e "s/@WITH_TOOLS@/1/g" dist/libbytesize.spec'
+    create-archive:
+      - './autogen.sh'
+      - './configure'
+      - 'make'
+      - 'make local'
+      - 'bash -c "ls *.tar*"'
 
 - job: propose_downstream
   trigger: release


### PR DESCRIPTION
We don't want to bump the release to 99 for the downstream builds.